### PR TITLE
Fix vulnerabilities on main

### DIFF
--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -147,4 +147,30 @@
     </notes>
     <cve>CVE-2021-33880</cve>
   </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[
+    file name: Microsoft.AspNetCore.Hosting.Abstractions.dll
+    See https://github.com/dotnet/announcements/issues/111 for MS details on this CVE.
+        Package name: System.Text.RegularExpressions.dll (included as part of the .Net Core runtime)
+      	Vulnerable versions: 4.3.0 and below
+        Secure versions: 4.3.1+
+    This CVE applies to .Net Core versions below 2.2.107 (runtime 2.2.5). MSI is pinned to .Net core SDK > 3.1.408 which is not vulnerable, and deployed to Azure App Service which will have the security patch applied.
+    ]]>
+    </notes>
+    <cve>CVE-2019-0820</cve>
+  </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[
+    file name: System.Net.Http:4.3.3
+    See https://github.com/dotnet/announcements/issues/111 for MS details on this CVE.
+        Package name: System.Net.Http:4.3.3 (included as part of the .Net Core runtime)
+      	Vulnerable versions: 4.3.3 and below
+        Secure versions: 4.3.4+
+    This CVE applies to .NET Core 2.1, .NET Core 1.0, .NET Core 1.1, PowerShell Core 6.0. MSI is pinned to .Net core SDK > 3.1.408 which is not vulnerable, and deployed to Azure App Service which will have the security patch applied.
+    ]]>
+    </notes>
+    <cve>CVE-2018-8292</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
Vulnerabilities fixed for timebeing
suppressed the respective CV( Out of two, one(System.Text.RegularExpressions) is already suppressed in FSS, we have added the same in MSI and the other one(System.Net.Http) is lower version used in FSS, so for time being we have suppressed this as well, considering it won't affect .Net Core 6.1