### PR TITLE
54614 Upgrade dotnet API to fix CVE-2022-34716

### DIFF
--- a/UKHO.MaritimeSafetyInformation.Web/UKHO.MaritimeSafetyInformation.Common/UKHO.MaritimeSafetyInformation.Common.csproj
+++ b/UKHO.MaritimeSafetyInformation.Web/UKHO.MaritimeSafetyInformation.Common/UKHO.MaritimeSafetyInformation.Common.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.Identity.Web" Version="1.25.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
     <PackageReference Include="UKHO.FileShareAdminClient" Version="1.4.20530.4" />
     <PackageReference Include="UKHO.FileShareClient" Version="1.4.20530.4" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.22047.3" />

--- a/UKHO.MaritimeSafetyInformation.Web/UKHO.MaritimeSafetyInformation.Web/UKHO.MaritimeSafetyInformation.Web.csproj
+++ b/UKHO.MaritimeSafetyInformation.Web/UKHO.MaritimeSafetyInformation.Web/UKHO.MaritimeSafetyInformation.Web.csproj
@@ -47,6 +47,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
     <PackageReference Include="UKHO.FileShareAdminClient" Version="1.5.20802.4" />
     <PackageReference Include="UKHO.FileShareClient" Version="1.5.20802.4" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.22047.3" />

--- a/UKHO.MaritimeSafetyInformation.Web/UKHO.MaritimeSafetyInformationAdmin.Web/UKHO.MaritimeSafetyInformationAdmin.Web.csproj
+++ b/UKHO.MaritimeSafetyInformation.Web/UKHO.MaritimeSafetyInformationAdmin.Web/UKHO.MaritimeSafetyInformationAdmin.Web.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.22047.3" />
   </ItemGroup>
 

--- a/UKHO.MaritimeSafetyInformation.Web/global.json
+++ b/UKHO.MaritimeSafetyInformation.Web/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.101",
+    "version": "6.0.108",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This has fixes for the following CVEs:

- https://github.com/advisories/GHSA-2m65-m22p-9wjw - requires a dotnet SDK bump (https://dev.azure.com/ukhydro/Maritime%20Safety%20Information/_workitems/edit/52293)

This is related to an Abzu task (https://dev.azure.com/ukhydro/Abzu/_workitems/edit/54558)

