### PR TITLE
Update Terraform

### DIFF
--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.89.0"
+      version = "=3.116.0"
     }
   }
 
-  required_version = "=1.7.2"
+  required_version = "=1.9.6"
   backend "azurerm" {
     container_name = "tfstate"
     key            = "terraform.deployment.tfplan"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ variables:
   - name: UKHOAssemblyCopyright
     value: "Copyright © UK Hydrographic Office"
   - name: Container
-    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.7.2"
+    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.9.6"
   - name: DeploymentPool
     value: "Mare Nectaris"
   - name: WindowsPool


### PR DESCRIPTION
#### PR Classification
Version updates for Terraform and Docker container image.

#### PR Summary
Updated versions for Terraform and Docker container image to ensure compatibility and leverage new features.
- `azure.tf`: Updated `azurerm` provider from `3.89.0` to `3.116.0` and Terraform required version from `1.7.2` to `1.9.6`.
- `azure-pipelines.yml`: Updated Docker container image version from `1.7.2` to `1.9.6`.
