### PR TITLE
Abzu-190254-fix-file-transformation

### DIFF
--- a/Deployment/templates/continuous-dacpac-app-deployment.yml
+++ b/Deployment/templates/continuous-dacpac-app-deployment.yml
@@ -34,7 +34,7 @@ steps:
     displayName: "File Transform: WebAppSettings"
     inputs:
       folderPath: '$(Pipeline.Workspace)/MaritimeSafetyInformation/*.zip'
-      xmlTransformationRules:
+      xmlTransformationRules: false
       jsonTargetFiles: '**/appsettings.json'  
 
   - task: AzureCLI@2
@@ -100,7 +100,7 @@ steps:
     displayName: "File Transform: Admin-WebAppSettings"
     inputs:
       folderPath: '$(Pipeline.Workspace)/MaritimeSafetyInformationAdmin/*.zip'
-      xmlTransformationRules:
+      xmlTransformationRules: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: AzureCLI@2

--- a/Deployment/templates/continuous-dacpac-app-deployment.yml
+++ b/Deployment/templates/continuous-dacpac-app-deployment.yml
@@ -34,7 +34,7 @@ steps:
     displayName: "File Transform: WebAppSettings"
     inputs:
       folderPath: '$(Pipeline.Workspace)/MaritimeSafetyInformation/*.zip'
-      xmlTransformationRules: false
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'  
 
   - task: AzureCLI@2
@@ -100,7 +100,7 @@ steps:
     displayName: "File Transform: Admin-WebAppSettings"
     inputs:
       folderPath: '$(Pipeline.Workspace)/MaritimeSafetyInformationAdmin/*.zip'
-      xmlTransformationRules: false
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: AzureCLI@2

--- a/Deployment/templates/continuous-deployment.yml
+++ b/Deployment/templates/continuous-deployment.yml
@@ -10,7 +10,7 @@ steps:
     displayName: "File Transform: Msi Config" #Replace msi instance value from pipeline 
     inputs:
       folderPath: '$(Pipeline.Workspace)/terraformartifact/src'
-      xmlTransformationRules: false
+      enableXmlTransform: false
       jsonTargetFiles: 'appsettings.json'
 
   - task: PowerShell@2

--- a/Deployment/templates/continuous-deployment.yml
+++ b/Deployment/templates/continuous-deployment.yml
@@ -10,7 +10,7 @@ steps:
     displayName: "File Transform: Msi Config" #Replace msi instance value from pipeline 
     inputs:
       folderPath: '$(Pipeline.Workspace)/terraformartifact/src'
-      xmlTransformationRules:
+      xmlTransformationRules: false
       jsonTargetFiles: 'appsettings.json'
 
   - task: PowerShell@2

--- a/Deployment/templates/continuous-testing.yml
+++ b/Deployment/templates/continuous-testing.yml
@@ -17,7 +17,7 @@ steps:
       displayName: "File Transform: integrationtests"
       inputs:
        folderPath: '$(Build.SourcesDirectory)/IntegrationTests/'
-       xmlTransformationRules:
+       xmlTransformationRules: false
        jsonTargetFiles: '**/appsettings.json'
 
     - task: UseDotNet@2
@@ -62,7 +62,7 @@ steps:
     - task: FileTransform@2
       inputs:
        folderPath: '$(Build.SourcesDirectory)\Tests\Configuration'
-       xmlTransformationRules:
+       xmlTransformationRules: false
        jsonTargetFiles: 'appConfig.json'
 
     - script: |

--- a/Deployment/templates/continuous-testing.yml
+++ b/Deployment/templates/continuous-testing.yml
@@ -17,7 +17,7 @@ steps:
       displayName: "File Transform: integrationtests"
       inputs:
        folderPath: '$(Build.SourcesDirectory)/IntegrationTests/'
-       xmlTransformationRules: false
+       enableXmlTransform: false
        jsonTargetFiles: '**/appsettings.json'
 
     - task: UseDotNet@2
@@ -62,7 +62,7 @@ steps:
     - task: FileTransform@2
       inputs:
        folderPath: '$(Build.SourcesDirectory)\Tests\Configuration'
-       xmlTransformationRules: false
+       enableXmlTransform: false
        jsonTargetFiles: 'appConfig.json'
 
     - script: |


### PR DESCRIPTION
#### PR Classification
Code fix to correct XML transformation settings in deployment and testing pipelines after up[date from Microsoft.]

#### PR Summary
Updated `FileTransform@2` tasks to disable XML transformation in deployment and testing YAML files.
- `continuous-dacpac-app-deployment.yml`: Replaced `xmlTransformationRules` with `enableXmlTransform: false` for "WebAppSettings" and "Admin-WebAppSettings".
- `continuous-deployment.yml`: Updated "Msi Config" task by removing `xmlTransformationRules` and adding `enableXmlTransform: false`.
- `continuous-testing.yml`: Modified two tasks to replace `xmlTransformationRules` with `enableXmlTransform: false` for "File Transform: integrationtests" and files in 'Tests\Configuration' directory.
