### PR TITLE
Upgrade .NET, Terraform, and Azure pipeline for compatibility

### DIFF
--- a/Deployment/src/Modules/Webapp/main.tf
+++ b/Deployment/src/Modules/Webapp/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_windows_web_app" "webapp_service" {
   site_config {
      application_stack {    
      current_stack = "dotnet"
-     dotnet_version = "v8.0"
+     dotnet_version = "v10.0"
     }
     always_on  = true
     ftps_state = "Disabled"
@@ -55,7 +55,7 @@ resource "azurerm_windows_web_app_slot" "webapp_service_staging" {
   site_config {
      application_stack {    
      current_stack = "dotnet"
-     dotnet_version = "v8.0"
+     dotnet_version = "v10.0"
     }
     always_on  = true
     ftps_state = "Disabled"
@@ -95,7 +95,7 @@ resource "azurerm_windows_web_app" "admin_webapp_service" {
   site_config {
      application_stack {    
      current_stack = "dotnet"
-     dotnet_version = "v8.0"
+     dotnet_version = "v10.0"
     }
     always_on  = true
     ftps_state = "Disabled"
@@ -130,7 +130,7 @@ resource "azurerm_windows_web_app_slot" "admin_webapp_service_staging" {
   site_config {
      application_stack {    
      current_stack = "dotnet"
-     dotnet_version = "v8.0"
+     dotnet_version = "v10.0"
     }
     always_on  = true
     ftps_state = "Disabled"

--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.116.0"
+      version = "=4.81.0"
     }
   }
 
-  required_version = "=1.9.6"
+  required_version = "=1.15.8"
   backend "azurerm" {
     container_name = "tfstate"
     key            = "terraform.deployment.tfplan"

--- a/Deployment/terraform_conditional_run.ps1
+++ b/Deployment/terraform_conditional_run.ps1
@@ -11,7 +11,7 @@ cd $env:AGENT_BUILDDIRECTORY/terraformartifact/src
 terraform --version
 
 Write-output "Executing terraform scripts for deployment in $workSpace enviroment"
-terraform init -backend-config="resource_group_name=$deploymentResourceGroupName" -backend-config="storage_account_name=$deploymentStorageAccountName" -backend-config="key=terraform.deployment.tfplan"
+terraform init -upgrade -backend-config="resource_group_name=$deploymentResourceGroupName" -backend-config="storage_account_name=$deploymentStorageAccountName" -backend-config="key=terraform.deployment.tfplan"
 if ( !$? ) { echo "Something went wrong during terraform initialization"; throw "Error" }
 
 Write-output "Selecting workspace"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ variables:
 - name: UKHOAssemblyCopyright
   value: "Copyright © UK Hydrographic Office"
 - name: Container
-  value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.9.6"
+  value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.15.8"
 - name: DeploymentPool
   value: "Mare Nectaris"
 - name: WindowsPool1
@@ -45,7 +45,7 @@ variables:
 - name: WindowsPool2
   value: "Mare Nubium"
 - name: DotNetSdkVersion
-  value: "9.x"
+  value: "10.0.x"
 - name: snykAbzuOrganizationId
   value: aeb7543b-8394-457c-8334-a31493d8910d
 


### PR DESCRIPTION
This pull request updates the deployment pipeline to support .NET 10.0 and upgrades key dependencies to ensure compatibility and access to the latest features. The most important changes are:

**.NET Version Upgrades:**

* Updated the `dotnet_version` in all Azure Web App and slot resources in `main.tf` from `v8.0` to `v10.0` to deploy and run .NET 10.0 applications.
* Changed the `DotNetSdkVersion` pipeline variable in `azure-pipelines.yml` from `9.x` to `10.0.x` to ensure the build uses the correct .NET SDK version.

**Terraform and Container Upgrades:**

* Upgraded the Terraform provider version in `azure.tf` from `3.116.0` to `4.81.0` and the required Terraform version from `1.9.6` to `1.15.8` for improved features and compatibility.
* Updated the pipeline container image in `azure-pipelines.yml` to use version `1.15.8`, matching the new Terraform version.
* Added the `-upgrade` flag to `terraform init` in `terraform_conditional_run.ps1` to ensure providers and modules are updated during initialization.